### PR TITLE
replace "over" with "requires" to fix deprecation

### DIFF
--- a/lib/Mojolicious/Plugin/WithCSRFProtection.pm
+++ b/lib/Mojolicious/Plugin/WithCSRFProtection.pm
@@ -40,7 +40,7 @@ sub register {
     $routes->add_shortcut(
         with_csrf_protection => sub {
             my ($route) = @_;
-            return $route->over( with_csrf_protection => 1 );
+            return $route->requires( with_csrf_protection => 1 );
         }
     );
 


### PR DESCRIPTION
Replace the deprecated Mojolicious::Routes::Route::over with Mojolicious::Routes::Route::requires.

tests pass. will probably need to update the required version of Mojolicious.